### PR TITLE
Creating testing binary to test basic behavior of fuse and daemon binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.o
 clr_debug_fuse
 clr_debug_daemon
+test-driver
+testing_fuse
+testing_daemon
 .deps/
 .dirstamp
 Makefile
@@ -29,3 +32,8 @@ config.guess
 config.sub
 libtool
 ltmain.sh
+test-suite.log
+testing_fuse.log
+testing_fuse.trs
+testing_daemon.log
+testing_daemon.trs

--- a/Makefile.am
+++ b/Makefile.am
@@ -45,3 +45,12 @@ clr_debug_daemon_LDADD = ${curl_LIBS} libnica.la ${LIBSYSTEMD_LIBS}
 systemdsystemunit_DATA = clr_debug_fuse.service clr_debug_daemon.service clr_debug_daemon.socket
 
 tmpfiles_DATA = debuginfo.conf
+
+# Functional Testing
+noinst_PROGRAMS = testing_fuse testing_daemon
+
+testing_fuse_SOURCES = tests/testing_fuse.c
+testing_fuse_CFLAGS = $(AM_CFLAGS)
+
+testing_daemon_SOURCES = tests/testing_daemon.c
+testing_daemon_CFLAGS = $(AM_CFLAGS)

--- a/tests/testing_daemon.c
+++ b/tests/testing_daemon.c
@@ -1,0 +1,104 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "config.h"
+
+#define BUFFER_LENGTH 16
+
+int get_server_socket(void)
+{
+        int sockfd;
+        struct sockaddr_un serveraddr;
+        fputs("Creating socket\n", stderr);
+        sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+        if (sockfd < 0) {
+                fputs("Fail creating socket\n", stderr);
+                return -1;
+        }
+        memset(&serveraddr, 0, sizeof(serveraddr));
+        serveraddr.sun_family = AF_UNIX;
+        strcpy(serveraddr.sun_path, SOCKET_PATH);
+
+        fputs("Connecting to server\n", stderr);
+        if (connect(sockfd, (struct sockaddr*)&serveraddr,
+                    offsetof(struct sockaddr_un, sun_path) + strlen(SOCKET_PATH) + 1) < 0) {
+                fprintf(stderr, "Fail connecting to server: %s\n", strerror(errno));
+                close(sockfd);
+                return -1;
+        }
+        return sockfd;
+}
+
+
+int testing_daemon(void)
+{
+        int sockfd;
+        char buffer[BUFFER_LENGTH];
+
+        if((sockfd = get_server_socket()) < 0) {
+                return -1;
+        }
+
+        fputs("Sending message to server\n", stderr);
+        memset(buffer, 0, sizeof(buffer));
+        strcpy(buffer, "0:lib:/lib");
+        if(send(sockfd, buffer, sizeof(buffer), 0) < 0) {
+                fputs("Fail sending message to socket service\n", stderr);
+                close(sockfd);
+                return -1;
+        }
+
+        fputs("Receiving message from server\n", stderr);
+        memset(buffer, 0, sizeof(buffer));
+        if (recv(sockfd, &buffer[0],
+                 BUFFER_LENGTH, 0) < 0) {
+                fputs("Failing receiving message from socket service\n", stderr);
+                close(sockfd);
+                return -1;
+        }
+
+        close(sockfd);
+        return strcmp(buffer, "ok") && access("/var/cache/debuginfo/lib/lib", F_OK) != -1;
+}
+
+int main(void)
+{
+        int res = 0;
+        pid_t p;
+        p = fork();
+        if (p == 0) {
+                if (freopen("/dev/null", "w", stderr) == NULL)
+                        return -1;
+                char *args[] = {"./clr_debug_daemon", NULL};
+                execvp("./clr_debug_daemon", args);
+        } else if (p > 0) {
+                sleep(1);
+                res = testing_daemon();
+                kill(p, SIGKILL);
+        } else {
+                fputs("error executing fork\n", stderr);
+        }
+        unlink(SOCKET_PATH);
+        return res;
+}
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/tests/testing_fuse.c
+++ b/tests/testing_fuse.c
@@ -1,0 +1,170 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <grp.h>
+#include <linux/capability.h>
+#include <linux/limits.h>
+#include <malloc.h>
+#include <pwd.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "config.h"
+
+#define TIMEOUT 600
+#define MAX_CONNECTIONS 16
+
+int check_file_request(int fd, char *expected_str)
+{
+        char buf[PATH_MAX + 8];
+        int clientsock;
+        malloc_trim(0);
+        fputs("Accepting connection\n", stderr);
+        clientsock = accept(fd, NULL, NULL);
+        if (clientsock < 0)
+                return -1;
+
+        memset(buf, 0, sizeof(buf));
+        fputs("Reading socket content\n", stderr);
+        if (read(clientsock, buf, PATH_MAX + 8) < 0)
+                return -1;
+        close(clientsock);
+        return strncmp(buf, expected_str, strlen(expected_str));
+}
+
+int get_service_socket(void)
+{
+        int sockfd;
+        struct sockaddr_un sun;
+        signal(SIGPIPE, SIG_IGN);
+        fputs("Creating socket\n", stderr);
+        sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+        if (sockfd < 0) {
+                fputs("Fail creating socket\n", stderr);
+                return -1;
+        }
+
+        printf("Socket path %s\n", SOCKET_PATH);
+        sun.sun_family = AF_UNIX;
+        strcpy(sun.sun_path, SOCKET_PATH);
+
+        fputs("Binding socket\n", stderr);
+        if (bind(sockfd, (struct sockaddr*)&sun,
+                   offsetof(struct sockaddr_un, sun_path) + strlen(SOCKET_PATH) + 1) < 0) {
+                fprintf(stderr, "fail bind: %s\n", strerror(errno));
+                close(sockfd);
+                return -1;
+        }
+
+        if (listen(sockfd, 16) < 0) {
+                fputs("Fail listening socket \n", stderr);
+                close(sockfd);
+                return -1;
+        }
+        return sockfd;
+}
+
+
+int testing_fuse(void)
+{
+        int sockfd;
+        uid_t gdb_user = 0;
+        gid_t gdb_group = 0;
+        struct passwd *passwdentry;
+        pid_t p2;
+        int test_result = -1;
+        umask(0);
+        passwdentry =  getpwnam("gdbinfo");
+        if (passwdentry) {
+                gdb_user = passwdentry->pw_uid;
+                gdb_group = passwdentry->pw_gid;
+        }
+        endpwent();
+
+        if (prctl(PR_SET_DUMPABLE, 0) != 0) {
+                fputs("fail prctl\n", stderr);
+        }
+
+        if (geteuid() == 0) {
+                if (prctl(PR_CAPBSET_DROP, CAP_SYS_ADMIN) !=0) {
+                        fprintf(stderr, "fail geteuid: %s\n", strerror(errno));
+                }
+        }
+
+        if ((sockfd = get_service_socket()) < 0) {
+                return 1;
+        }
+
+        if (setgid(gdb_group)) {
+                fputs("fail setgid\n", stderr);
+        }
+
+        if (setgroups(1, &gdb_group)) {
+                fputs("fail setgroups\n", stderr);
+        }
+
+        if (setuid(gdb_user)) {
+                fputs("fail setuid\n", stderr);
+        }
+
+        p2 = fork();
+        if (p2 > 0) {
+                test_result = check_file_request(sockfd, "0:lib:/tmp");
+        } else if (p2 == 0) {
+                if (freopen("/dev/null", "w", stderr) == NULL)
+                        exit(1);
+                char *args[] = {"/usr/bin/cat", "/usr/lib/debug/tmp", NULL};
+                execvp("/usr/bin/cat", args);
+        } else {
+                fputs("error executing fork\n", stderr);
+                return 1;
+        }
+
+        wait(NULL);
+        close(sockfd);
+        return test_result;
+}
+
+int main(void)
+{
+        int res = 0;
+        pid_t p;
+        p = fork();
+        if (p == 0) {
+                if (freopen("/dev/null", "w", stderr) == NULL)
+                        return -1;
+                char *args[] = {"./clr_debug_fuse", NULL};
+                execvp("./clr_debug_fuse", args);
+        } else if (p > 0) {
+                res = testing_fuse();
+                kill(p, SIGKILL);
+        } else {
+                fputs("error executing fork\n", stderr);
+                return 1;
+        }
+        unlink(SOCKET_PATH);
+        return res;
+}
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */


### PR DESCRIPTION

- creating a fake socket check if fuse is sending the request properly to
  the socket service.
- make a request to the server socket while clr_debug_daemon is running
to check that it is responding propertly and also that it is creating cache files
- change makefile.am to compile binaries without add them to the installation process

Signed-off-by: Josue David Hernandez Gutierrez <josue.d.hernandez.gutierrez@intel.com>